### PR TITLE
Fix PDF Text Extraction Spacing and Ordering

### DIFF
--- a/src/app/actions/extract.ts
+++ b/src/app/actions/extract.ts
@@ -26,11 +26,26 @@ export async function extractText(formData: FormData) {
                             // Custom text extraction to fix spacing issues
                             let text = "";
                             pdfData.formImage.Pages.forEach((page: any) => {
-                                page.Texts.forEach((item: any) => {
-                                    item.R.forEach((t: any) => {
-                                        // decode and append with space
-                                        text += decodeURIComponent(t.T) + " ";
+                                // Sort texts by Y then X
+                                const sortedTexts = [...page.Texts].sort((a: any, b: any) => {
+                                    if (Math.abs(a.y - b.y) < 0.1) {
+                                        return a.x - b.x;
+                                    }
+                                    return a.y - b.y;
+                                });
+
+                                let lastY = -1;
+                                sortedTexts.forEach((item: any) => {
+                                    if (lastY !== -1 && Math.abs(item.y - lastY) >= 0.1) {
+                                        text += "\n";
+                                    } else if (lastY !== -1) {
+                                        text += " ";
+                                    }
+
+                                    item.R.forEach((r: any) => {
+                                        text += decodeURIComponent(r.T);
                                     });
+                                    lastY = item.y;
                                 });
                                 text += "\n";
                             });

--- a/src/app/api/analyze/route.ts
+++ b/src/app/api/analyze/route.ts
@@ -36,11 +36,26 @@ export async function POST(req: NextRequest) {
                             // Custom text extraction to fix spacing issues
                             let text = "";
                             pdfData.formImage.Pages.forEach((page: any) => {
-                                page.Texts.forEach((item: any) => {
-                                    item.R.forEach((t: any) => {
-                                        // decode and append with space
-                                        text += decodeURIComponent(t.T) + " ";
+                                // Sort texts by Y then X
+                                const sortedTexts = [...page.Texts].sort((a: any, b: any) => {
+                                    if (Math.abs(a.y - b.y) < 0.1) {
+                                        return a.x - b.x;
+                                    }
+                                    return a.y - b.y;
+                                });
+
+                                let lastY = -1;
+                                sortedTexts.forEach((item: any) => {
+                                    if (lastY !== -1 && Math.abs(item.y - lastY) >= 0.1) {
+                                        text += "\n";
+                                    } else if (lastY !== -1) {
+                                        text += " ";
+                                    }
+
+                                    item.R.forEach((r: any) => {
+                                        text += decodeURIComponent(r.T);
                                     });
+                                    lastY = item.y;
                                 });
                                 text += "\n";
                             });


### PR DESCRIPTION
The PDF text extraction was previously using a naive approach that appended spaces after every text run and newlines after every text item, regardless of their position on the page. This led to fragmented text, incorrect word order, and missing proper line breaks.

This change introduces a more robust algorithm that:
1. Sorts all text elements on a page by their Y-coordinate and then by their X-coordinate.
2. Groups elements that are vertically close (within 0.1 units) into the same line.
3. Joins elements on the same line with a single space.
4. Inserts newlines between detected lines.
5. Correctly decodes URI-encoded characters from the PDF data.

These improvements ensure that the extracted resume text maintains its original structure and readability, which is critical for accurate analysis by the AI.

---
*PR created automatically by Jules for task [10236324499082704027](https://jules.google.com/task/10236324499082704027) started by @aniruddhaadak80*