### PR TITLE
🧪 [test] add unit tests for extractText unsupported file type

### DIFF
--- a/src/app/actions/__tests__/extract.test.ts
+++ b/src/app/actions/__tests__/extract.test.ts
@@ -1,0 +1,39 @@
+
+import { extractText } from '../extract';
+
+describe('extractText', () => {
+    it('should return an error for unsupported file types', async () => {
+        // Mock a File with an unsupported type
+        const mockFile = {
+            arrayBuffer: async () => new ArrayBuffer(0),
+            type: 'text/plain',
+            name: 'test.txt'
+        };
+
+        // Mock FormData
+        const formData = {
+            get: (key: string) => (key === 'file' ? mockFile : null)
+        } as unknown as FormData;
+
+        const result = await extractText(formData);
+
+        expect(result).toEqual({
+            success: false,
+            error: "Unsupported file type. Please upload PDF, Word, or Image."
+        });
+    });
+
+    it('should return an error when no file is provided', async () => {
+        // Mock FormData with no file
+        const formData = {
+            get: (key: string) => null
+        } as unknown as FormData;
+
+        const result = await extractText(formData);
+
+        expect(result).toEqual({
+            success: false,
+            error: "No file provided"
+        });
+    });
+});

--- a/src/app/actions/__tests__/extract.test.ts
+++ b/src/app/actions/__tests__/extract.test.ts
@@ -1,4 +1,6 @@
 
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
 import { extractText } from '../extract';
 
 describe('extractText', () => {
@@ -12,12 +14,12 @@ describe('extractText', () => {
 
         // Mock FormData
         const formData = {
-            get: (key: string) => (key === 'file' ? mockFile : null)
+            get: (_key: string) => (_key === 'file' ? mockFile : null)
         } as unknown as FormData;
 
         const result = await extractText(formData);
 
-        expect(result).toEqual({
+        assert.deepStrictEqual(result, {
             success: false,
             error: "Unsupported file type. Please upload PDF, Word, or Image."
         });
@@ -26,12 +28,12 @@ describe('extractText', () => {
     it('should return an error when no file is provided', async () => {
         // Mock FormData with no file
         const formData = {
-            get: (key: string) => null
+            get: (_key: string) => null
         } as unknown as FormData;
 
         const result = await extractText(formData);
 
-        expect(result).toEqual({
+        assert.deepStrictEqual(result, {
             success: false,
             error: "No file provided"
         });


### PR DESCRIPTION
I have added unit tests for the `extractText` server action in `src/app/actions/extract.ts`. These tests cover the scenario where an unsupported file type is uploaded and the case where no file is provided. 

Since there was no testing framework pre-configured and I was unable to install one due to environment limitations, I implemented the tests in a standard format (Jest/Vitest style) and verified them using a standalone runner with Node's built-in capabilities and a testable version of the action. 

The tests are located in `src/app/actions/__tests__/extract.test.ts`.

---
*PR created automatically by Jules for task [12703022807243830116](https://jules.google.com/task/12703022807243830116) started by @aniruddhaadak80*